### PR TITLE
Don't edit if existing text matches replacement text.

### DIFF
--- a/powerdeletesuite.js
+++ b/powerdeletesuite.js
@@ -413,8 +413,8 @@ var pd = {
           pd.actions.page.shift();
           pd.actions.page.next();
         } else if (shouldBeActedOn) {
-          var textMatch = (item.data.body === pd.task.config.editText) ||
-            (item.data.selftext  === pd.task.config.editText);
+          var textMatch = (item.data.body == pd.task.config.editText) ||
+            (item.data.selftext == pd.task.config.editText);
           if (!item.pdEdited && ((item.data.is_self || item.kind == 't1') && pd.task.config.isEditing) && !textMatch) {
             pd.actions.edit(item);
           } else if (!item.pdDeleted && ((item.kind == 't3' && pd.task.config.isRemovingPosts) || (item.kind == 't1' && pd.task.config.isRemovingComments))) {

--- a/powerdeletesuite.js
+++ b/powerdeletesuite.js
@@ -412,6 +412,9 @@ var pd = {
           pd.actions.page.shift();
           pd.actions.page.next();
         } else if (shouldBeActedOn) {
+          item.pdEdited = item.pdEdited || (
+            (item.data.body === pd.task.config.editText) || (item.data.selftext  === pd.task.config.editText)
+          );
           if (!item.pdEdited && ((item.data.is_self || item.kind == 't1') && pd.task.config.isEditing)) {
             pd.actions.edit(item);
           } else if (!item.pdDeleted && ((item.kind == 't3' && pd.task.config.isRemovingPosts) || (item.kind == 't1' && pd.task.config.isRemovingComments))) {

--- a/powerdeletesuite.js
+++ b/powerdeletesuite.js
@@ -158,6 +158,7 @@ var pd = {
             mod: 0,
             score: 0,
             date: 0,
+            match: 0,
           }
         },
         config: {
@@ -412,14 +413,16 @@ var pd = {
           pd.actions.page.shift();
           pd.actions.page.next();
         } else if (shouldBeActedOn) {
-          item.pdEdited = item.pdEdited || (
-            (item.data.body === pd.task.config.editText) || (item.data.selftext  === pd.task.config.editText)
-          );
-          if (!item.pdEdited && ((item.data.is_self || item.kind == 't1') && pd.task.config.isEditing)) {
+          var textMatch = (item.data.body === pd.task.config.editText) ||
+            (item.data.selftext  === pd.task.config.editText);
+          if (!item.pdEdited && ((item.data.is_self || item.kind == 't1') && pd.task.config.isEditing) && !textMatch) {
             pd.actions.edit(item);
           } else if (!item.pdDeleted && ((item.kind == 't3' && pd.task.config.isRemovingPosts) || (item.kind == 't1' && pd.task.config.isRemovingComments))) {
             pd.actions.delete(item);
           } else {
+            if (textMatch) {
+              pd.task.info.ignoreReasons['match'] ++;
+            } 
             pd.actions.children.finishItem();
             pd.actions.children.handleGroup();
           }

--- a/powerdeletesuite.js
+++ b/powerdeletesuite.js
@@ -422,6 +422,7 @@ var pd = {
           } else {
             if (textMatch) {
               pd.task.info.ignoreReasons['match'] ++;
+              pd.task.items[0].pdIgnored = true;
             } 
             pd.actions.children.finishItem();
             pd.actions.children.handleGroup();


### PR DESCRIPTION
Update Boolean value of `pdEdited` (if `false`) based on whether or not the existing text matches the replacement text. If `pdEdited` is already `true`, this update will not change that value. This will prevent updating entries that already match the replacement text.

UPDATE: ❌